### PR TITLE
fix: ralph API is accesible on tutor local

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,11 +30,16 @@ Usage
 
     tutor plugins enable ralph
 
-2. Save the changes to the environment::
+2. Optionally, you can allow the LRS API to accesible by domain by setting the following variables in you **config.yml** (only if you are running **tutor local**):
+
+    RALPH_ENABLE_PUBLIC_URL: true
+    RALPH_HOST: ralph.local.overhang.io
+
+3. Save the changes to the environment::
 
     tutor config save
 
-3. Run the initialization scripts in your chosen environment (dev or local)::
+4. Run the initialization scripts in your chosen environment (dev or local)::
 
     tutor [dev|local] do init
 

--- a/tutorralph/patches/caddyfile
+++ b/tutorralph/patches/caddyfile
@@ -1,0 +1,6 @@
+# Ralph
+{% if RALPH_ENABLE_PUBLIC_URL %}
+{{ RALPH_HOST }}{$default_site_port} {
+    import proxy "ralph:8100"
+}
+{% endif %}

--- a/tutorralph/plugin.py
+++ b/tutorralph/plugin.py
@@ -29,6 +29,7 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         ("RALPH_HTTP_PROTOCOL", 'http://'),
         ("RALPH_HOST", 'ralph'),
         ("RALPH_PORT", '8100'),
+        ("RALPH_ENABLE_PUBLIC_URL", False),
     ]
 )
 


### PR DESCRIPTION
This PR makes ralph web server accesible when running `tutor local`.

As this behavior may not be the one expected for every installation, this will not be the default behavior.