### PR TITLE
refactor: use patch files instead

### DIFF
--- a/tutorralph/patches/local-docker-compose-services
+++ b/tutorralph/patches/local-docker-compose-services
@@ -1,0 +1,20 @@
+ralph:
+    image: docker.io/fundocker/{{ RALPH_IMAGE_NAME }}:{{ RALPH_IMAGE_TAG }}
+    depends_on:
+      clickhouse:
+        condition: service_healthy
+    env_file:
+      - ../../env/plugins/ralph/apps/config/env
+    ports:
+      - "{{ RALPH_PORT }}:{{ RALPH_PORT }}"
+    command:
+      - python 
+      - "-m"
+      - ralph
+      - "-v"
+      - DEBUG
+      - runserver
+      - "-b"
+      - "clickhouse"
+    volumes:
+      - ../../env/plugins/ralph/apps/config/ralph_auth/:/app/.ralph

--- a/tutorralph/plugin.py
+++ b/tutorralph/plugin.py
@@ -179,34 +179,6 @@ hooks.Filters.ENV_TEMPLATE_TARGETS.add_items(
     ],
 )
 
-hooks.Filters.ENV_PATCHES.add_item(
-    (
-        "local-docker-compose-services",
-        """
-ralph:
-    image: docker.io/fundocker/{{ RALPH_IMAGE_NAME }}:{{ RALPH_IMAGE_TAG }}
-    depends_on:
-      clickhouse:
-        condition: service_healthy
-    env_file:
-      - ../../env/plugins/ralph/apps/config/env
-    ports:
-      - "{{ RALPH_PORT }}:{{ RALPH_PORT }}"
-    command:
-      - python 
-      - "-m"
-      - ralph
-      - "-v"
-      - DEBUG
-      - runserver
-      - "-b"
-      - "clickhouse"
-    volumes:
-      - ../../env/plugins/ralph/apps/config/ralph_auth/:/app/.ralph
-        """
-    )
-)
-
 ########################################
 # PATCH LOADING
 # (It is safe & recommended to leave


### PR DESCRIPTION
## Description

This PR uses docker patches to improve readability

## Testing instructions

For testing you can configure a development environment using the following script:

```bash
virtualenv -p python3.8 venv && source venv/bin/activate
git clone --branch=nightly https://github.com/overhangio/tutor.git
pip install -e "./tutor[full]"
export TUTOR_PLUGINS_ROOT=$(pwd)/plugins/ export TUTOR_ROOT=$(pwd)
git clone https://github.com/openedx/tutor-contrib-oars
git clone https://github.com/openedx/tutor-contrib-ralph
git clone https://github.com/openedx/tutor-contrib-clickhouse
git clone https://github.com/openedx/tutor-contrib-superset
pip install -e ./tutor-contrib-clickhouse
pip install -e ./tutor-contrib-ralph
pip install -e ./tutor-contrib-oars
pip install -e ./tutor-contrib-superset
tutor plugins enable oars
tutor plugins enable ralph
tutor plugins enable clickhouse
tutor plugins enable superset
tutor config save
```

Then create a local git repository including all the changes. The following **.gitignore** can be used as a reference:

```
tutor-contrib-clickhouse
tutor-contrib-oars
tutor-contrib-ralph
tutor-contrib-superset
tutor
venv
data

**/k8s/jobs.yml
**/env/version
**/superset_home
venv/

__pycache__/
*.py[cod]
```

Then, you can review this branch and run tutor config save. The only difference should be in some blank characters but the overall result is the same.

The modified files should be:
- **env/dev/docker-compose.yml**
- **env/dev/docker-compose.jobs.yml**
- **env/local/docker-compose.yml**
- **env/local/docker-compose.jobs.yml**

## References

For reference, all official tutor plugins use files instead of patches programmatically:

https://github.com/overhangio/tutor-discovery/tree/master/tutordiscovery/patches
https://github.com/overhangio/tutor-notes/tree/master/tutornotes/patches
Among others
