### PR TITLE
fix: use correct clickhouse port

### DIFF
--- a/tutorralph/patches/k8s-deployments
+++ b/tutorralph/patches/k8s-deployments
@@ -36,7 +36,7 @@ spec:
             - name: RALPH_BACKENDS__DATABASE__CLICKHOUSE__PASSWORD
               value: "{{CLICKHOUSE_ADMIN_PASSWORD}}"
             - name: RALPH_BACKENDS__DATABASE__CLICKHOUSE__PORT
-              value: "{{CLICKHOUSE_PORT}}"
+              value: "{{CLICKHOUSE_HTTP_PORT}}"
             - name: RALPH_BACKENDS__DATABASE__CLICKHOUSE__TEST_HOST
               value: "clickhouse"
             - name: RALPH_BACKENDS__DATABASE__CLICKHOUSE__USERNAME


### PR DESCRIPTION
## Description

This PR fixes and issue in which the ralph API cannot connect to clickhouse because the port is wrong (9000 instead of 8123)